### PR TITLE
Pdf upload preview

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -24,7 +24,7 @@ export function FileUpload({ onFileSelect }: FileUploadProps) {
         };
         reader.readAsDataURL(file);
       } else {
-        // For non-image files like PDFs, clear any existing image preview
+        // For non-image files like PDFs, clear image preview
         setPreview(null);
       }
     }

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
-import { Upload, X } from 'lucide-react';
+import { Upload, X, FileText } from 'lucide-react';
 
 interface FileUploadProps {
   onFileSelect: (file: File) => void;
@@ -8,10 +8,12 @@ interface FileUploadProps {
 
 export function FileUpload({ onFileSelect }: FileUploadProps) {
   const [preview, setPreview] = useState<string | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
     if (acceptedFiles.length > 0) {
       const file = acceptedFiles[0];
+      setSelectedFile(file);
       onFileSelect(file);
       
       // Create preview for image files
@@ -21,6 +23,9 @@ export function FileUpload({ onFileSelect }: FileUploadProps) {
           setPreview(reader.result as string);
         };
         reader.readAsDataURL(file);
+      } else {
+        // For non-image files like PDFs, clear any existing image preview
+        setPreview(null);
       }
     }
   }, [onFileSelect]);
@@ -34,9 +39,10 @@ export function FileUpload({ onFileSelect }: FileUploadProps) {
     maxFiles: 1
   });
 
-  const clearPreview = (e: React.MouseEvent) => {
+  const clearSelection = (e: React.MouseEvent) => {
     e.stopPropagation();
     setPreview(null);
+    setSelectedFile(null);
     onFileSelect(null as any);
   };
 
@@ -51,7 +57,7 @@ export function FileUpload({ onFileSelect }: FileUploadProps) {
         {preview ? (
           <div className="relative">
             <button
-              onClick={clearPreview}
+              onClick={clearSelection}
               className="absolute -top-2 -right-2 p-1 bg-red-500 text-white rounded-full hover:bg-red-600 z-10"
             >
               <X className="w-4 h-4" />
@@ -61,6 +67,21 @@ export function FileUpload({ onFileSelect }: FileUploadProps) {
               alt="Preview"
               className="max-h-64 mx-auto rounded-lg shadow-md"
             />
+          </div>
+        ) : selectedFile && selectedFile.type === 'application/pdf' ? (
+          <div className="relative">
+            <button
+              onClick={clearSelection}
+              className="absolute -top-2 -right-2 p-1 bg-red-500 text-white rounded-full hover:bg-red-600 z-10"
+            >
+              <X className="w-4 h-4" />
+            </button>
+            <div className="flex flex-col items-center bg-gray-50 p-6 rounded-lg">
+              <FileText className="w-16 h-16 text-blue-600 mb-3" />
+              <p className="font-medium text-gray-800">{selectedFile.name}</p>
+              <p className="text-sm text-gray-500 mt-1">{(selectedFile.size / 1024).toFixed(1)} KB</p>
+              <p className="mt-3 text-sm font-medium text-blue-600">PDF document selected</p>
+            </div>
           </div>
         ) : (
           <div className="flex flex-col items-center text-gray-600">


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/0d5ce52d-e541-4350-88dd-3ae1a5321c5d)

### Problem
Previously, when users uploaded a PDF file, there was no visual confirmation that the file had been successfully selected. While image uploads displayed a preview, PDFs had no visual feedback, leading to confusion about whether the upload was successful

---
### Changes

- Added visual confirmation when a PDF file is uploaded
- Displays PDF icon, filename, and file size when a PDF is selected
- Shows clear "PDF document selected" confirmation message
- Added ability to remove the selected PDF with a delete button
- Improved state management with a dedicated `selectedFile` state variable

---
### Benefits

Provides clear visual feedback to users when they upload PDF files, improving the overall user experience and reducing confusion. Users now receive immediate confirmation that their PDF has been successfully selected before evaluation